### PR TITLE
Update react-event-listener for Flow fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "prop-types": "^15.5.10",
-    "react-event-listener": "^0.4.5"
+    "react-event-listener": "^0.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
This picks up https://github.com/oliviertassinari/react-event-listener/commit/6805df821ccdabe291ac0f9b64b0fe31fd2b8a4b, which fixes typings on `flow` >= 0.53.1 .

Without this fix:

```
react-event-listener/src/index.js:49
 49:   children?: React.Element<any>,
                  ^^^^^^^^^^^^^^^^^^ Element. Property not found in
                              v-
234:   declare export default {|
235:     +DOM: typeof DOM,
236:     +PropTypes: typeof PropTypes,
...:
248:   |};
       -^ object type. See lib: /private/tmp/flow/flowlib_41292a5/react.js:234

Error: node_modules/react-scrollbar-size/node_modules/react-event-listener/src/index.js:102
102: class EventListener extends Component {
                                 ^^^^^^^^^ identifier `Component`. Too few type arguments. Expected at least 1
 29: declare class React$Component<Props, State = void> {
                                   ^^^^^^^^^^^^ See type parameters of definition here.
```