### PR TITLE
Change dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 updates:
-- package-ecosystem: npm
+- package-ecosystem: "npm"
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
+    interval: "weekly"
+    day: "saturday"
+    time: "00:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
## Description :memo:

A daily dependabot schedule appears to be creating too many pull requests to efficiently manage.  This PR switches to a weekly dependabot schedule.
