### PR TITLE
Eliminate lodash

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,13 @@ module.exports = {
 	},
 	overrides: [
 		{
+			files: ['**/index.*'],
+			rules: {
+				// allow named export
+				'import/prefer-default-export': 'off',
+			},
+		},
+		{
 			files: ['**/scripts/**', '**/example/**', '**/__tests__/**', '**/*.test.ts', '**/*.test.tsx'],
 			rules: {
 				// allow dev dependencies

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,5 +27,16 @@
         "<node_internals>/**/*.js"
       ],
     },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Debug Parcel via Chrome",
+      "url": "http://localhost:1234",
+      "webRoot": "${workspaceFolder}",
+      "breakOnLoad": true,
+      "sourceMapPathOverrides": {
+        "../*": "${webRoot}/*"
+      },
+    },
   ],
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,9 @@ module.exports = {
 	restoreMocks: true, // restore initial behavior of mocked functions
 	moduleFileExtensions: ['js', 'ts', 'tsx'],
 	collectCoverageFrom: [
-		'**/src/*.ts', // test typescript files
-		'**/src/*.tsx', // test typescript files that render JSX
-		'!**/src/**/index.ts', // do not test index export files
+		'**/src/**/*.ts', // typescript files
+		'**/src/**/*.tsx', // typescript files that render JSX
+		'!**/src/**/index.ts', // do not cover index export files
 	],
 	coverageThreshold: {
 		global: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2458,21 +2458,6 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.157",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.157.tgz",
-      "integrity": "sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==",
-      "dev": true
-    },
-    "@types/lodash.debounce": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
-      "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/node": {
       "version": "14.0.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
@@ -4099,6 +4084,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {
@@ -9503,11 +9497,6 @@
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
       "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "npm run clean:build",
     "clean:build": "rimraf build",
     "example": "parcel ./example/index.html",
+    "example:debug": "cross-env BABEL_ENV=debug && parcel ./example/index.html",
     "lint": "eslint . --ext js,ts,tsx --cache && echo \"eslint: no lint errors\"",
     "lint:fix": "eslint . --ext js,ts,tsx --fix",
     "prebuild": "npm run clean:build",
@@ -42,9 +43,7 @@
   "peerDependencies": {
     "react": "^16.8.0"
   },
-  "dependencies": {
-    "lodash.debounce": "^4.0.8"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.5",
@@ -55,12 +54,12 @@
     "@testing-library/react": "^10.4.7",
     "@types/fs-extra": "^9.0.1",
     "@types/jest": "^26.0.7",
-    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^14.0.26",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
+    "cross-env": "^7.0.2",
     "eslint": "^7.5.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-config-prettier": "^6.11.0",

--- a/src/ScrollbarSize.tsx
+++ b/src/ScrollbarSize.tsx
@@ -1,5 +1,5 @@
-import debounce from 'lodash.debounce';
 import React, { CSSProperties, FunctionComponent, ReactElement, useEffect, useRef } from 'react';
+import { debounce } from './utils';
 
 /** Styles for the div that will be generated for measuring scrollbar size */
 const styles: CSSProperties = {

--- a/src/utils/__tests__/debounce.test.ts
+++ b/src/utils/__tests__/debounce.test.ts
@@ -1,0 +1,39 @@
+import debounce from '../debounce';
+
+const wait = 1000;
+const spy = jest.fn();
+const debouncedFn = debounce(spy, wait);
+
+test('should only fire the debounced function once it has not run for the defined wait period', () => {
+	expect(spy).not.toHaveBeenCalled();
+	debouncedFn(); // run the function
+	expect(spy).not.toHaveBeenCalled();
+	jest.advanceTimersByTime(wait - 1); // advance to just before the wait period
+	expect(spy).not.toHaveBeenCalled();
+	jest.advanceTimersByTime(1); // advance to the wait period
+	expect(spy).toHaveBeenCalledTimes(1);
+});
+
+test('should reset the timer if debounced function runs before wait period has elapsed', () => {
+	expect(spy).not.toHaveBeenCalled();
+	debouncedFn(); // run the function
+	expect(spy).not.toHaveBeenCalled();
+	jest.advanceTimersByTime(wait - 1); // advance to just before the wait period
+	expect(spy).not.toHaveBeenCalled();
+	debouncedFn(); // run again
+	expect(spy).not.toHaveBeenCalled();
+	jest.advanceTimersByTime(wait - 1); // advance to just before the wait period
+	expect(spy).not.toHaveBeenCalled();
+	jest.advanceTimersByTime(1); // advance to the wait period
+	expect(spy).toHaveBeenCalledTimes(1);
+});
+
+test('should cancel the execution of the debounced function', () => {
+	expect(spy).not.toHaveBeenCalled();
+	debouncedFn(); // run the function
+	jest.advanceTimersByTime(wait - 1);
+	expect(spy).not.toHaveBeenCalled();
+	debouncedFn.cancel(); // cancel right before wait ends
+	jest.advanceTimersByTime(wait); // advance beyond the wait period
+	expect(spy).not.toHaveBeenCalled();
+});

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -5,7 +5,7 @@ interface DebouncedFn<F extends (...args: any[]) => void> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const debounce = <F extends (...args: any[]) => void>(func: F, waitFor: number): DebouncedFn<F> => {
+const debounce = <F extends (...args: any[]) => void>(fn: F, waitFor: number): DebouncedFn<F> => {
 	let timeout: NodeJS.Timeout | null;
 
 	const clear = () => {
@@ -19,7 +19,7 @@ const debounce = <F extends (...args: any[]) => void>(func: F, waitFor: number):
 		clear();
 
 		timeout = setTimeout(() => {
-			func(...args);
+			fn(...args);
 		}, waitFor);
 	};
 

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,33 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface DebouncedFn<F extends (...args: any[]) => void> {
+	(...args: Parameters<F>): void;
+	cancel: () => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const debounce = <F extends (...args: any[]) => void>(func: F, waitFor: number): DebouncedFn<F> => {
+	let timeout: NodeJS.Timeout | null;
+
+	const clear = () => {
+		if (timeout != null) {
+			clearTimeout(timeout);
+			timeout = null;
+		}
+	};
+
+	const debouncedFn = (...args: Parameters<F>): void => {
+		clear();
+
+		timeout = setTimeout(() => {
+			func(...args);
+		}, waitFor);
+	};
+
+	debouncedFn.cancel = () => {
+		clear();
+	};
+
+	return debouncedFn;
+};
+
+export default debounce;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as debounce } from './debounce';


### PR DESCRIPTION
## Description :memo:

After being prodded by @kthompson23, this PR eliminates lodash as a dependency and adds an internalized debounce function.

## Type of change :gem:

<!-- Please delete options that are not relevant. -->

- [X] Refactor

## How Has This Been Tested? :vertical_traffic_light:
<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

* Existing unit tests continue to pass
* New unit tests added for debounce function
* Ran example and confirmed functionality is still working as desired
* Added console.log statements during debounce testing to ensure firing at the appropriate times

## Checklist :checkered_flag:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] My changes pass lint, prettier, and TS checks
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
