### PR TITLE
Deprecate node 12.x and 13.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,5 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - 12.19.0
-                - 13.14.0
-                - 14.15.0
-                - 15.1.0
+                - 14.15.1
+                - 15.3.0

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/STORIS/react-scrollbar-size#readme",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.1"


### PR DESCRIPTION
## Description :memo:

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR deprecates node 12.x and 13.x from official support.  The CI pipeline has eliminated those versions from its steps and the engines have been updated in `package.json`.

Node 12.x went into maintenance on 2020-11-30.  Node 12.x went end-of-life on 2020-06-01.

## Type of change :gem:

<!-- Please delete options that are not relevant. -->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
