### PR TITLE
Increase dependabot PR limit to 25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     interval: "weekly"
     day: "saturday"
     time: "00:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 25


### PR DESCRIPTION
## Description :memo:

Dependabot will often create more than 10 pull requests on the weekly schedule.  The current configuration is to limit pull requests to 10 which means there are additional queued up.  This is problematic for packages that need to be updated at the same time (e.g. babel family, eslint family, etc.).

This PR updates the limit to 25.

## Checklist :checkered_flag:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] My changes pass lint, prettier, and TS checks
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
